### PR TITLE
fix: link validation to consider single character domains

### DIFF
--- a/src/components/LinkPreview.js
+++ b/src/components/LinkPreview.js
@@ -15,7 +15,7 @@ const isValidUrlProp = (props, propName, componentName) => {
 
 const isValidUrl = (url) => {
   const regex =
-    /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/
+    /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/
   const validUrl = regex.test(url)
   return validUrl
 }


### PR DESCRIPTION
x.com links are considered as invalid as they do not pass the regex used for link validation. The validation considers a link is valid if there are 2 - 256 characters. This should be changed to allow 1 character as well

This PR will address issue #36 
